### PR TITLE
Added support for pf2e-dorako-ui module

### DIFF
--- a/fateroll/fate.js
+++ b/fateroll/fate.js
@@ -207,18 +207,32 @@ Hooks.once('init', function() {
 
 class Fatecontrol {
 
-    static addChatControl() {
-        const chatControlLeft = document.getElementsByClassName("chat-control-icon")[0];
+    static addChatControl() {        
         let tableNode = document.getElementById("FATE-button");
 
-        if (chatControlLeft && !tableNode) {
-            const chatControlLeftNode = chatControlLeft.firstElementChild;
-			const number = 4;
-            tableNode = document.createElement("label");
-            tableNode.innerHTML = `<i id="FATE-button" class="fas fa-yin-yang FATE-button" style="text-shadow: 0 0 1px black;margin-right: 5px;"></i>`;
-            tableNode.onclick = Fatecontrol.initializeFATE;
-            chatControlLeft.insertBefore(tableNode, chatControlLeftNode);
-        }
+		if (game.modules.get("pf2e-dorako-ui")?.active) {
+			const chatDorakoRtButtons = document.getElementById("dorako-rt-buttons");
+			if (chatDorakoRtButtons && !tableNode) {
+				const chatDorakoRtButtonsNode = chatDorakoRtButtons.firstElementChild;
+				tableNode = document.createElement("button");
+				tableNode.setAttribute("data-id", "FATE-button");
+				tableNode.setAttribute("id", "FATE-button");
+				tableNode.setAttribute("class", "button");
+				tableNode.setAttribute("title", "Fate Roll");
+				tableNode.innerHTML = `<i class="fas fa-yin-yang"></i>`;
+				tableNode.onclick = Fatecontrol.initializeFATE;
+				chatDorakoRtButtons.insertBefore(tableNode, chatDorakoRtButtonsNode);
+			}
+		} else {
+			const chatControlLeft = document.getElementsByClassName("chat-control-icon")[0];
+			if (chatControlLeft && !tableNode) {
+				const chatControlLeftNode = chatControlLeft.firstElementChild;
+				tableNode = document.createElement("label");
+				tableNode.innerHTML = `<i id="FATE-button" class="fas fa-yin-yang FATE-button" style="text-shadow: 0 0 1px black;margin-right: 5px;"></i>`;
+				tableNode.onclick = Fatecontrol.initializeFATE;
+				chatControlLeft.insertBefore(tableNode, chatControlLeftNode);
+			}
+		}
     }
 	
     static initializeFATE() {


### PR DESCRIPTION
The pf2e-dorako-ui module changes the way icons/buttons around chat looks like and hides everything under the `chat-control-icon` as default setting. To make this looks nicer and show up with default settings, I added additional condition for just pf2e-dorako-ui module to add FATE button to better suited place and use theme CSS to look it better.

This is how it looks after changes: 
<img width="267" alt="Zrzut ekranu 2024-01-18 o 10 22 35" src="https://github.com/Handyfon/roll-of-fate/assets/1120451/f116a549-3a25-4184-9087-7732e251059c">